### PR TITLE
Perform a check

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Set Node.js options to handle OpenSSL compatibility issues
+export NODE_OPTIONS="--openssl-legacy-provider"
+
+# Start the Docusaurus development server
+echo "Starting Cardano Developer Portal..."
+yarn start


### PR DESCRIPTION
## Quickfix

Adds a `start.sh` script to simplify running the Docusaurus development server. This script includes the `NODE_OPTIONS="--openssl-legacy-provider"` environment variable, which is necessary to resolve OpenSSL compatibility issues with the older Docusaurus version (2.0.0-beta.6) and newer Node.js versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4926449-4902-4b5a-89f2-81cce45d7468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4926449-4902-4b5a-89f2-81cce45d7468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

